### PR TITLE
use sha256sum instead of shasum

### DIFF
--- a/bin/install
+++ b/bin/install
@@ -57,7 +57,7 @@ verify() {
     echo "gpg verification failed" >&2
     return 1
   fi
-  if ! (cd "${TMP_DOWNLOAD_DIR}" && shasum -a 256 -c <(grep "${platform}_${arch}.zip" "${checksum_path}")); then
+  if ! (cd "${TMP_DOWNLOAD_DIR}" && sha256sum -c <(grep "${platform}_${arch}.zip" "${checksum_path}")); then
     echo "checksum verification failed" >&2
     return 2
   fi


### PR DESCRIPTION
in some distributions like alpine the binary shasum is not present.